### PR TITLE
Use sendMessageDraft for smooth real-time streaming

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -474,9 +474,9 @@ export function createWorker(botConfig: BotConfig, bridge: ClaudeBridge, tunnelM
         buffer = "";
         currentActivity = "";
 
-        // Update display to show waiting state
+        // Clear display before sending plan as real messages
         if (draftActive) {
-          await bot.api.sendMessageDraft(chatId, draftId, "Waiting for plan approval...").catch(() => {});
+          await bot.api.sendMessageDraft(chatId, draftId, " ").catch(() => {});
         } else {
           await doEdit();
         }


### PR DESCRIPTION
Replace the editMessageText-based streaming with Telegram's sendMessageDraft (Bot API 9.3+) for animated, flicker-free message streaming. Falls back to editMessageText when drafts are unsupported (e.g. group chats, old clients).

Key changes:
- Draft-first initialization with graceful fallback
- Reduced debounce from 1500ms to 300ms for drafts
- Clean lifecycle handling (onResult, onError, cancellation, plan approval)
- Plain text during streaming to avoid HTML parse issues mid-stream

## What

Brief description of the change.

## Why

Motivation / issue link.

## How

Key implementation details or trade-offs.

## Testing

- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Tested manually with a bot (if applicable)
