### PR TITLE
Add /yolo command to toggle bypass-permissions mode

### DIFF
--- a/src/claude.ts
+++ b/src/claude.ts
@@ -166,6 +166,7 @@ export class ClaudeBridge {
   private lastQueryEnd = new Map<number, number>();
   private lastPrompts = new Map<number, string>();
   private sessionApprovedTools = new Map<number, Set<string>>();
+  private yoloChats = new Set<number>();
   // Strip CLAUDECODE env var once so SDK subprocesses don't refuse to start
   // when the daemon is launched from within a Claude Code session.
   private readonly cleanEnv: Record<string, string | undefined>;
@@ -214,7 +215,20 @@ export class ClaudeBridge {
     this.sessions.delete(chatId);
     this.sessionTokens.delete(chatId);
     this.sessionApprovedTools.delete(chatId);
+    this.yoloChats.delete(chatId);
     this.saveState();
+  }
+
+  setYolo(chatId: number, enabled: boolean): void {
+    if (enabled) {
+      this.yoloChats.add(chatId);
+    } else {
+      this.yoloChats.delete(chatId);
+    }
+  }
+
+  isYolo(chatId: number): boolean {
+    return this.yoloChats.has(chatId);
   }
 
   setModel(chatId: number, modelId: string): void {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -111,6 +111,7 @@ export function createWorker(botConfig: BotConfig, bridge: ClaudeBridge, tunnelM
     "/cost — Show token usage for the current session\n" +
     "/session — Get session ID to continue in CLI\n" +
     "/resume — Resume a CLI session in Telegram\n" +
+    "/yolo — Toggle skip-permissions mode (no approval prompts)\n" +
     "/cancel — Abort the current operation\n" +
     "/feedback — Send feedback or report an issue\n" +
     "/help — Show this help message\n\n" +
@@ -180,6 +181,26 @@ export function createWorker(botConfig: BotConfig, bridge: ClaudeBridge, tunnelM
       await ctx.reply("Operation cancelled.");
     } else {
       await ctx.reply("Nothing running to cancel.");
+    }
+  });
+
+  bot.command("yolo", async (ctx) => {
+    const chatId = ctx.chat.id;
+    const enabling = !bridge.isYolo(chatId);
+    bridge.setYolo(chatId, enabling);
+    if (enabling) {
+      await ctx.reply(
+        "\u26a0\ufe0f <b>YOLO mode ON</b>\n\n" +
+          "All tools will run <b>without approval</b>. " +
+          "Claude can execute any command, edit any file, and access the network without asking.\n\n" +
+          "Use /yolo again to disable.",
+        { parse_mode: "HTML" }
+      );
+    } else {
+      await ctx.reply(
+        "\u2705 <b>YOLO mode OFF</b>\n\nTools will require approval again.",
+        { parse_mode: "HTML" }
+      );
     }
   });
 
@@ -832,7 +853,7 @@ export function createWorker(botConfig: BotConfig, bridge: ClaudeBridge, tunnelM
         onSessionReset: () => {
           bot.api.sendMessage(chatId, "Previous session not found. Starting a fresh session.").catch(() => {});
         },
-      });
+      }, bridge.isYolo(chatId) ? "bypassPermissions" : "default");
 
       // Runs if cancelled (onResult/onError were never called)
       if (!responseHandled) {


### PR DESCRIPTION
## Summary
- Adds `/yolo` command to Worker Bot that toggles `bypassPermissions` mode per chat, allowing all tools to run without manual Telegram approval
- Session-scoped state (resets on `/new` or daemon restart), opt-in only with a strong security warning on every enable
- Leverages existing `permissionMode: "bypassPermissions"` already used by the scheduler and daemon

Closes #15

## Changes
- `src/claude.ts`: Added `yoloChats` Set + `setYolo()`/`isYolo()` methods to `ClaudeBridge`, cleared on `clearSession()`
- `src/worker.ts`: Added `/yolo` toggle command with ⚠️ warning, updated help text, passes permission mode to `bridge.sendMessage()`

## Test plan
- [x] TypeScript compiles with no errors (`npx tsc --noEmit`)
- [x] All 55 existing tests pass (`npm test`)
- [ ] Manual test: `/yolo` → warning shown → send prompt → no approval buttons → `/yolo` again → disabled → approval buttons return
- [ ] Manual test: `/new` resets YOLO state

🤖 Generated with [Claude Code](https://claude.com/claude-code)