### PR TITLE
Fix project .claude/ settings not loaded by SDK

### DIFF
--- a/src/claude.ts
+++ b/src/claude.ts
@@ -472,6 +472,7 @@ export class ClaudeBridge {
           model,
           includePartialMessages: true,
           permissionMode,
+          settingSources: ['user', 'project', 'local'],
           ...(maxTurns ? { maxTurns } : {}),
           ...(sessionId ? { resume: sessionId } : {}),
           abortController,


### PR DESCRIPTION
## Summary
- The `query()` call in `ClaudeBridge.sendMessage()` was missing the `settingSources` option
- Without it, the SDK runs in **isolation mode** — all project-level `.claude/` files are silently ignored:
  - `.claude/settings.json` (project settings)
  - `.claude/settings.local.json` (local settings)
  - `CLAUDE.md` (project instructions)
  - `.claude/commands/` (custom commands)
  - `~/.claude/settings.json` (user global settings)
- Added `settingSources: ['user', 'project', 'local']` to load all three layers

## Changes
- `src/claude.ts`: Added `settingSources: ['user', 'project', 'local']` to `query()` options

## Test plan
- [x] TypeScript compiles with no errors
- [x] All 55 existing tests pass
- [ ] Manual test: create `.claude/settings.json` in a worker project, verify settings are respected
- [ ] Manual test: add `CLAUDE.md` to a worker project, verify Claude follows the instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)