### PR TITLE
Sync project .claude/commands/ and .claude/skills/ to Telegram bot commands

### DIFF
--- a/src/claude.ts
+++ b/src/claude.ts
@@ -279,6 +279,41 @@ export class ClaudeBridge {
     return path.join(os.homedir(), ".claude", "projects", projectKey);
   }
 
+  /**
+   * Scan .claude/commands/ in the project working directory and return
+   * discovered custom commands with names and descriptions.
+   */
+  discoverProjectCommands(): Array<{ command: string; description: string }> {
+    const commandsDir = path.join(this.workingDir, ".claude", "commands");
+    if (!fs.existsSync(commandsDir)) return [];
+
+    try {
+      const files = fs.readdirSync(commandsDir).filter(f => f.endsWith(".md"));
+      return files.map(f => {
+        const name = f.replace(/\.md$/, "");
+        // Use first non-empty line of the file as description, fallback to name
+        let description = `Project command: ${name}`;
+        try {
+          const content = fs.readFileSync(path.join(commandsDir, f), "utf-8");
+          const firstLine = content.split("\n").find(l => l.trim().length > 0)?.trim();
+          if (firstLine) {
+            // Strip markdown heading prefix
+            const cleaned = firstLine.replace(/^#+\s*/, "");
+            if (cleaned.length > 0 && cleaned.length <= 256) {
+              description = cleaned;
+            }
+          }
+        } catch {}
+        // Telegram command names: lowercase, digits, underscores only, 1-32 chars
+        const tgName = name.toLowerCase().replace(/[^a-z0-9_]/g, "_").slice(0, 32);
+        if (!tgName) return null;
+        return { command: tgName, description };
+      }).filter((c): c is { command: string; description: string } => c !== null);
+    } catch {
+      return [];
+    }
+  }
+
   listRecentSessions(limit = 10): Array<{ sessionId: string; modifiedAt: Date; promptPreview: string }> {
     const dir = this.getProjectSessionsDir();
     if (!fs.existsSync(dir)) return [];
@@ -472,6 +507,7 @@ export class ClaudeBridge {
           model,
           includePartialMessages: true,
           permissionMode,
+          settingSources: ['user', 'project', 'local'],
           ...(maxTurns ? { maxTurns } : {}),
           ...(sessionId ? { resume: sessionId } : {}),
           abortController,

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -280,38 +280,59 @@ export class ClaudeBridge {
   }
 
   /**
-   * Scan .claude/commands/ in the project working directory and return
-   * discovered custom commands with names and descriptions.
+   * Scan .claude/commands/ and .claude/skills/ in the project working directory
+   * and return discovered custom commands/skills with names and descriptions.
+   *
+   * Commands: .claude/commands/<name>.md
+   * Skills:   .claude/skills/<name>/SKILL.md
    */
   discoverProjectCommands(): Array<{ command: string; description: string }> {
-    const commandsDir = path.join(this.workingDir, ".claude", "commands");
-    if (!fs.existsSync(commandsDir)) return [];
+    const results: Array<{ command: string; description: string }> = [];
+    const seen = new Set<string>();
 
-    try {
-      const files = fs.readdirSync(commandsDir).filter(f => f.endsWith(".md"));
-      return files.map(f => {
-        const name = f.replace(/\.md$/, "");
-        // Use first non-empty line of the file as description, fallback to name
-        let description = `Project command: ${name}`;
-        try {
-          const content = fs.readFileSync(path.join(commandsDir, f), "utf-8");
-          const firstLine = content.split("\n").find(l => l.trim().length > 0)?.trim();
-          if (firstLine) {
-            // Strip markdown heading prefix
-            const cleaned = firstLine.replace(/^#+\s*/, "");
-            if (cleaned.length > 0 && cleaned.length <= 256) {
-              description = cleaned;
-            }
+    const addEntry = (name: string, filePath: string, fallbackLabel: string) => {
+      const tgName = name.toLowerCase().replace(/[^a-z0-9_]/g, "_").slice(0, 32);
+      if (!tgName || seen.has(tgName)) return;
+      seen.add(tgName);
+
+      let description = `${fallbackLabel}: ${name}`;
+      try {
+        const content = fs.readFileSync(filePath, "utf-8");
+        const firstLine = content.split("\n").find(l => l.trim().length > 0)?.trim();
+        if (firstLine) {
+          const cleaned = firstLine.replace(/^#+\s*/, "");
+          if (cleaned.length > 0 && cleaned.length <= 256) {
+            description = cleaned;
           }
-        } catch {}
-        // Telegram command names: lowercase, digits, underscores only, 1-32 chars
-        const tgName = name.toLowerCase().replace(/[^a-z0-9_]/g, "_").slice(0, 32);
-        if (!tgName) return null;
-        return { command: tgName, description };
-      }).filter((c): c is { command: string; description: string } => c !== null);
-    } catch {
-      return [];
-    }
+        }
+      } catch {}
+      results.push({ command: tgName, description });
+    };
+
+    // Scan .claude/commands/<name>.md
+    const commandsDir = path.join(this.workingDir, ".claude", "commands");
+    try {
+      if (fs.existsSync(commandsDir)) {
+        for (const f of fs.readdirSync(commandsDir).filter(f => f.endsWith(".md"))) {
+          addEntry(f.replace(/\.md$/, ""), path.join(commandsDir, f), "Command");
+        }
+      }
+    } catch {}
+
+    // Scan .claude/skills/<name>/SKILL.md
+    const skillsDir = path.join(this.workingDir, ".claude", "skills");
+    try {
+      if (fs.existsSync(skillsDir)) {
+        for (const dir of fs.readdirSync(skillsDir)) {
+          const skillFile = path.join(skillsDir, dir, "SKILL.md");
+          if (fs.existsSync(skillFile)) {
+            addEntry(dir, skillFile, "Skill");
+          }
+        }
+      }
+    } catch {}
+
+    return results;
   }
 
   listRecentSessions(limit = 10): Array<{ sessionId: string; modifiedAt: Date; promptPreview: string }> {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -30,7 +30,7 @@ const WORKER_COMMANDS = [
   { command: "session",    description: "Get session ID to resume in CLI" },
   { command: "resume",     description: "Resume a CLI session in Telegram" },
   { command: "yolo",       description: "Toggle skip-permissions mode" },
-  { command: "commands",   description: "List project custom commands" },
+  { command: "commands",   description: "List project commands and skills" },
   { command: "cancel",     description: "Abort the current operation" },
   { command: "feedback",   description: "Send feedback or report an issue" },
   { command: "help",       description: "Show help" },

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -29,6 +29,8 @@ const WORKER_COMMANDS = [
   { command: "cost",       description: "Show token usage for this session" },
   { command: "session",    description: "Get session ID to resume in CLI" },
   { command: "resume",     description: "Resume a CLI session in Telegram" },
+  { command: "yolo",       description: "Toggle skip-permissions mode" },
+  { command: "commands",   description: "List project custom commands" },
   { command: "cancel",     description: "Abort the current operation" },
   { command: "feedback",   description: "Send feedback or report an issue" },
   { command: "help",       description: "Show help" },
@@ -57,7 +59,16 @@ async function startWorker(botConfig: BotConfig): Promise<void> {
   const bot = createWorker(botConfig, bridge, tunnelManager, scheduleManager);
 
   await bot.init();
-  await bot.api.setMyCommands(WORKER_COMMANDS);
+
+  // Merge built-in commands with project-level .claude/commands/
+  const projectCommands = bridge.discoverProjectCommands();
+  const builtinNames = new Set(WORKER_COMMANDS.map(c => c.command));
+  const extraCommands = projectCommands.filter(c => !builtinNames.has(c.command));
+  const allCommands = [...WORKER_COMMANDS, ...extraCommands].slice(0, 100); // TG limit: 100
+  await bot.api.setMyCommands(allCommands);
+  if (extraCommands.length > 0) {
+    console.log(`[${botConfig.username}] Registered ${extraCommands.length} project command(s): ${extraCommands.map(c => "/" + c.command).join(", ")}`);
+  }
 
   addBot(botConfig);
   activeWorkers.set(botConfig.id, { config: botConfig, bot, bridge, tunnelManager });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -186,6 +186,7 @@ export function createWorker(botConfig: BotConfig, bridge: ClaudeBridge, tunnelM
     "/cost — Show token usage for the current session\n" +
     "/session — Get session ID to continue in CLI\n" +
     "/resume — Resume a CLI session in Telegram\n" +
+    "/commands — List project commands and skills\n" +
     "/cancel — Abort the current operation\n" +
     "/feedback — Send feedback or report an issue\n" +
     "/help — Show this help message\n\n" +
@@ -208,12 +209,41 @@ export function createWorker(botConfig: BotConfig, bridge: ClaudeBridge, tunnelM
     "• Some tools require your approval via Approve/Deny buttons\n" +
     "• Use /cancel if a response is taking too long";
 
+  // Discover project-level .claude/commands/ and .claude/skills/ for help text
+  const projectCommands = bridge.discoverProjectCommands();
+
+  function buildProjectCommandsText(): string {
+    if (projectCommands.length === 0) return "";
+    const lines = projectCommands.map(c => `/${escapeHtml(c.command)} — ${escapeHtml(c.description)}`);
+    return "\n\n<b>Project Commands &amp; Skills:</b>\n" + lines.join("\n") +
+      "\n\n<i>Defined in .claude/commands/ and .claude/skills/, executed by Claude.</i>";
+  }
+
   bot.command("start", async (ctx) => {
-    await ctx.reply(helpText, { parse_mode: "HTML" });
+    await ctx.reply(helpText + buildProjectCommandsText(), { parse_mode: "HTML" });
   });
 
   bot.command("help", async (ctx) => {
-    await ctx.reply(helpText, { parse_mode: "HTML" });
+    await ctx.reply(helpText + buildProjectCommandsText(), { parse_mode: "HTML" });
+  });
+
+  bot.command("commands", async (ctx) => {
+    if (projectCommands.length === 0) {
+      await ctx.reply(
+        "No project commands or skills found.\n\n" +
+          "Add <code>.md</code> files to <code>.claude/commands/</code> or " +
+          "<code>.claude/skills/&lt;name&gt;/SKILL.md</code> in your project to create custom commands.",
+        { parse_mode: "HTML" }
+      );
+      return;
+    }
+    const lines = projectCommands.map(c => `<b>/${escapeHtml(c.command)}</b> — ${escapeHtml(c.description)}`);
+    await ctx.reply(
+      `<b>Project commands &amp; skills</b> (${projectCommands.length})\n\n` +
+        lines.join("\n") +
+        "\n\n<i>Type any command to run it. Defined in .claude/commands/ and .claude/skills/</i>",
+      { parse_mode: "HTML" }
+    );
   });
 
   bot.command("new", async (ctx) => {


### PR DESCRIPTION
## Summary
- Loads project-level `.claude/` settings by adding `settingSources: ['user', 'project', 'local']` to the SDK `query()` call (includes PR #29 fix)
- Scans both `.claude/commands/` and `.claude/skills/` at worker startup, registers discovered entries as Telegram bot commands via `setMyCommands()` — users get autocomplete in TG
- Adds `/commands` command to list available project commands and skills
- Project commands/skills typed in TG (e.g. `/build_fix`, `/commit`) are forwarded as prompts to Claude, which recognizes them via loaded project settings

## How it works

```
Project: my-app/
├── .claude/
│   ├── commands/
│   │   ├── build-fix.md        → /build_fix in Telegram
│   │   └── test-coverage.md    → /test_coverage in Telegram
│   └── skills/
│       ├── commit/
│       │   └── SKILL.md        → /commit in Telegram
│       └── review/
│           └── SKILL.md        → /review in Telegram
```

1. **Startup**: `discoverProjectCommands()` scans `.claude/commands/*.md` and `.claude/skills/*/SKILL.md`, extracts name and description (first line of each file)
2. **TG registration**: Merges with built-in commands and calls `setMyCommands()` (respects TG 100-command limit, deduplicates)
3. **Routing**: Unregistered `/xxx` commands fall through grammy to `message:text` handler → sent as prompt to Claude → Claude recognizes the project command/skill
4. **Naming**: Filenames are sanitized to TG format (lowercase, underscores, max 32 chars)

## Changes
- `src/claude.ts`: Added `discoverProjectCommands()` method (scans commands + skills) + `settingSources` to `query()`
- `src/daemon.ts`: Merge project commands/skills with built-in commands at startup, added `/yolo` and `/commands` to command list
- `src/worker.ts`: Added `/commands` listing command, updated help text with project commands & skills section

## Test plan
- [x] TypeScript compiles with no errors
- [x] All 55 existing tests pass
- [ ] Manual test: create `.claude/commands/test.md` in project → restart worker → `/test` appears in TG autocomplete
- [ ] Manual test: create `.claude/skills/review/SKILL.md` → restart worker → `/review` appears in TG autocomplete
- [ ] Manual test: type `/commands` → lists both commands and skills
- [ ] Manual test: type `/test` or `/review` → Claude executes the project command/skill
- [ ] Manual test: project with neither directory → no errors, `/commands` shows "No project commands or skills found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)